### PR TITLE
fix weblate links and typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,23 +7,21 @@ behavior.**
 
 You are welcome to open issues to report bugs or suggest features, though. 🙂
 
-
 ## Bug fixes
 
 You are welcome to provide pull requests with fixes for a bug you discovered.
 Regarding code style: I don't dictate strict rules, but please try to stick to the original style as
 good as possible.
 
-
 ## Translations
 
-<a href="https://weblate.bubu1.eu/engage/currencies/">
-<img src="https://weblate.bubu1.eu/widgets/currencies/-/multi-auto.svg" alt="translation status" style="float: right; width: 50%;" />
+<a href="https://translate.codeberg.org/engage/currencies/">
+<img src="https://translate.codeberg.org/widgets/currencies/-/multi-auto.svg" alt="translation status" style="float: right; width: 50%;" />
 </a>
 
 You are invited to provide translations for the app. But there are some rules.
 
-1.  Please only translate if you are **fluid with the language** you provide the translation and
+1. Please only translate if you are **fluid with the language** you provide the translation and
     also if you are **familiar with the nomenclature of the Android system**. If in doubt about a
     specific string, check out other Apps of big companies, like WhatsApp, Facebook, Google, etc.,
     and see how they did it.
@@ -31,4 +29,4 @@ You are invited to provide translations for the app. But there are some rules.
    app, which is a mix of English and the native language. I might remove translations again, if
    they won't receive updates on new string resources.
 
-Translations can be provided via <a href="https://weblate.bubu1.eu/engage/currencies/">Weblate</a>.
+Translations can be provided via [Weblate](https://translate.codeberg.org/engage/currencies/).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- badges -->
 <div align="right">
-   <a href="https://weblate.bubu1.eu/engage/currencies/"><img alt="translation status" height="20" src="https://weblate.bubu1.eu/widgets/currencies/-/svg-badge.svg"></a>
+   <a href="https://translate.codeberg.org/engage/currencies/"><img alt="translation status" height="20" src="https://translate.codeberg.org/widgets/currencies/-/svg-badge.svg"></a>
    <img alt="build status" height="20" src="https://github.com/sal0max/currencies/actions/workflows/build.yaml/badge.svg">
 </div>
 
@@ -21,7 +21,6 @@ It is **not** intended to be used for realtime financial business, rather to be 
    <a href="https://www.paypal.com/donate?hosted_button_id=2JCY7E99V9DGC"><img alt="Donate with PayPal" height="75" src="https://raw.githubusercontent.com/aha999/DonateButtons/master/Paypal.png"></a>
 </div>
 
-
 ## Features
 
 * The app supports all relevant currencies. You can choose between several exchange rate providers:
@@ -36,7 +35,6 @@ It is **not** intended to be used for realtime financial business, rather to be 
 * **Currencies** is written for Android in Kotlin, targeting Android 13 and supporting light and dark themes.
 * The app is ad-free and doesn't spy on the user.
 
-
 ## Screenshots
 
 <div align="center">
@@ -44,15 +42,14 @@ It is **not** intended to be used for realtime financial business, rather to be 
    <img src="art/screenshots/screen03.png" width="45%" alt="screenshot 2">
 </div>
 
-
 ## Development
 
 Check out [CONTRIBUTING.md](CONTRIBUTING.md), if you are interested in participating.
 
-
 ## License
+
 Copyright 2021 Maximilian Salomon
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
+You should have received a copy of the GNU General Public License along with this program. If not, see [http://www.gnu.org/licenses](http://www.gnu.org/licenses/).


### PR DESCRIPTION
Hi @sal0max 

I just discovered a few links to the old **weblate** project (at *weblate.bubu1.eu*) apparently leftover from the recent migration to *translate.codeberg.org*. I also applied a few hints provided by the **markdown linting** of my IDE.

Looking forward to your feedback.
Regards,
Petra