### PR TITLE
Add keypad layout with 0 in the middle

### DIFF
--- a/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/main/MainActivity.kt
@@ -242,7 +242,7 @@ class MainActivity : BaseActivity() {
 
     private fun setListeners() {
         // long click on delete
-        arrayOf<View>(findViewById(R.id.keypad), findViewById(R.id.keypad_extended)).forEach {
+        arrayOf<View>(findViewById(R.id.keypad), findViewById(R.id.keypad_extended), findViewById(R.id.keypad_swapped)).forEach {
             it.findViewById<AppCompatImageButton>(R.id.btn_delete).setOnLongClickListener {
                 viewModel.clear()
                 true
@@ -438,16 +438,28 @@ class MainActivity : BaseActivity() {
             spinnerFrom.setCurrentSum(it)
         }
 
-        viewModel.isExtendedKeypadEnabled.observe(this) { extendedEnabled ->
+        viewModel.keypadType.observe(this) { keypadType ->
             val keypadRegular = findViewById<View>(R.id.keypad)
             val keypadExtended = findViewById<View>(R.id.keypad_extended)
-            // activate the correct keypad
-            keypadRegular.visibility = if (extendedEnabled) View.GONE else View.VISIBLE
-            keypadExtended.visibility = if (extendedEnabled) View.VISIBLE else View.GONE
+            val keypadSwapped = findViewById<View>(R.id.keypad_swapped)
+
+            // hide all keypads first
+            keypadRegular.visibility = View.GONE
+            keypadExtended.visibility = View.GONE
+            keypadSwapped.visibility = View.GONE
+
+            // show the correct keypad based on type
+            when (keypadType) {
+                0 -> keypadRegular.visibility = View.VISIBLE        // Standard keypad (0 on left)
+                1 -> keypadExtended.visibility = View.VISIBLE       // Extended keypad (00, 000)
+                2 -> keypadSwapped.visibility = View.VISIBLE        // Swapped keypad (0 in middle)
+            }
+
             // decimal button: use correct char for the current locale
             val separator = getDecimalSeparator(this)
-            keypadExtended.findViewById<TextView>(R.id.btn_decimal).text = separator
             keypadRegular.findViewById<TextView>(R.id.btn_decimal).text = separator
+            keypadExtended.findViewById<TextView>(R.id.btn_decimal).text = separator
+            keypadSwapped.findViewById<TextView>(R.id.btn_decimal).text = separator
         }
     }
 

--- a/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceFragment.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/view/preference/PreferenceFragment.kt
@@ -65,10 +65,10 @@ class PreferenceFragment: PreferenceFragmentCompat() {
             }
         }
 
-        // extended keypad
-        findPreference<SwitchPreferenceCompat>(getString(R.string.extendedKeypad_key))?.apply {
+        // keypad type
+        findPreference<ListPreference>(getString(R.string.keypadType_key))?.apply {
             setOnPreferenceChangeListener { _, newValue ->
-                viewModel.setExtendedKeypadEnabled(newValue.toString().toBoolean())
+                viewModel.setKeypadType(newValue.toString().toInt())
                 true
             }
         }

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/main/MainViewModel.kt
@@ -53,8 +53,7 @@ class MainViewModel(val app: Application, onlyCache: Boolean = false) : AndroidV
 
     // ui
     private var isUpdating: LiveData<Boolean> = repository.isUpdating()
-    val isExtendedKeypadEnabled: LiveData<Boolean> = Database(app).isExtendedKeypadEnabled()
-
+    val keypadType: LiveData<Int> = Database(app).getKeypadTypeAsync()
 
     // number input
     private val currentBaseValueText = MutableLiveData("0")

--- a/app/src/main/kotlin/de/salomax/currencies/viewmodel/preference/PreferenceViewModel.kt
+++ b/app/src/main/kotlin/de/salomax/currencies/viewmodel/preference/PreferenceViewModel.kt
@@ -135,8 +135,8 @@ class PreferenceViewModel(private val app: Application) : AndroidViewModel(app) 
         Database(app).setPreviewConversionEnabled(enabled)
     }
 
-    fun setExtendedKeypadEnabled(enabled: Boolean) {
-        Database(app).setExtendedKeypadEnabled(enabled)
+    fun setKeypadType(type: Int) {
+        Database(app).setKeypadType(type)
     }
 
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,4 +30,13 @@
         android:visibility="gone"
         tools:ignore="DuplicateIncludedIds" />
 
+    <include
+        android:id="@+id/keypad_swapped"
+        layout="@layout/main_keypad_swapped"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:visibility="gone"
+        tools:ignore="DuplicateIncludedIds" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/main_keypad_swapped.xml
+++ b/app/src/main/res/layout/main_keypad_swapped.xml
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- DON'T REMOVE! Outer frame layout needed; else RTL issues in land/activity_main! -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layoutDirection="ltr"
+        tools:ignore="HardcodedText,UselessParent">
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_7"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="numberEvent"
+            android:text="7"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            app:layout_constraintBottom_toTopOf="@id/btn_4"
+            app:layout_constraintEnd_toStartOf="@id/btn_8"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_8"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="numberEvent"
+            android:text="8"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_7"
+            app:layout_constraintEnd_toStartOf="@id/btn_9"
+            app:layout_constraintStart_toEndOf="@id/btn_7"
+            app:layout_constraintTop_toTopOf="@+id/btn_7" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_9"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="numberEvent"
+            android:text="9"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_7"
+            app:layout_constraintEnd_toStartOf="@id/btn_divide"
+            app:layout_constraintStart_toEndOf="@id/btn_8"
+            app:layout_constraintTop_toTopOf="@+id/btn_7" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_divide"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="calculationEvent"
+            android:text="÷"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            android:textColor="@color/color_keypad_operators"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_7"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/btn_9"
+            app:layout_constraintTop_toTopOf="@+id/btn_7" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_4"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="numberEvent"
+            android:text="4"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            app:layout_constraintBottom_toTopOf="@id/btn_1"
+            app:layout_constraintEnd_toStartOf="@id/btn_5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_7" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_5"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="numberEvent"
+            android:text="5"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_4"
+            app:layout_constraintEnd_toStartOf="@id/btn_6"
+            app:layout_constraintStart_toEndOf="@id/btn_4"
+            app:layout_constraintTop_toTopOf="@+id/btn_4" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_6"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="numberEvent"
+            android:text="6"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_4"
+            app:layout_constraintEnd_toStartOf="@id/btn_multiply"
+            app:layout_constraintStart_toEndOf="@id/btn_5"
+            app:layout_constraintTop_toTopOf="@+id/btn_4" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_multiply"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="calculationEvent"
+            android:text="×"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            android:textColor="@color/color_keypad_operators"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_4"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/btn_6"
+            app:layout_constraintTop_toTopOf="@+id/btn_4" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_1"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="numberEvent"
+            android:text="1"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            app:layout_constraintBottom_toTopOf="@id/btn_decimal"
+            app:layout_constraintEnd_toStartOf="@id/btn_2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_4" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_2"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="numberEvent"
+            android:text="2"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_1"
+            app:layout_constraintEnd_toStartOf="@id/btn_3"
+            app:layout_constraintStart_toEndOf="@id/btn_1"
+            app:layout_constraintTop_toTopOf="@+id/btn_1" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_3"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="numberEvent"
+            android:text="3"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_1"
+            app:layout_constraintEnd_toStartOf="@id/btn_subtract"
+            app:layout_constraintStart_toEndOf="@id/btn_2"
+            app:layout_constraintTop_toTopOf="@+id/btn_1" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_subtract"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="calculationEvent"
+            android:text="−"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            android:textColor="@color/color_keypad_operators"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/btn_3"
+            app:layout_constraintTop_toTopOf="@+id/btn_1" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_decimal"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="decimalEvent"
+            android:text="."
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/btn_0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_1" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_0"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="numberEvent"
+            android:text="0"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_decimal"
+            app:layout_constraintEnd_toStartOf="@id/btn_delete"
+            app:layout_constraintStart_toEndOf="@id/btn_decimal"
+            app:layout_constraintTop_toTopOf="@+id/btn_decimal" />
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/btn_delete"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:longClickable="true"
+            android:onClick="deleteEvent"
+            android:src="@drawable/ic_backspace"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_decimal"
+            app:layout_constraintEnd_toStartOf="@id/btn_add"
+            app:layout_constraintStart_toEndOf="@id/btn_0"
+            app:layout_constraintTop_toTopOf="@+id/btn_decimal"
+            tools:ignore="ContentDescription" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_add"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:onClick="calculationEvent"
+            android:text="+"
+            android:textAppearance="@style/AppTheme.TextAppearance.Keypad"
+            android:textColor="@color/color_keypad_operators"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_decimal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/btn_delete"
+            app:layout_constraintTop_toTopOf="@+id/btn_decimal" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/app/src/main/res/values/arrays_preference.xml
+++ b/app/src/main/res/values/arrays_preference.xml
@@ -13,4 +13,17 @@
         <item>2</item>
     </string-array>
 
+    <!-- keypad settings -->
+    <string-array name="keypad_names" translatable="false">
+        <item>@string/keypad_option_standard</item>
+        <item>@string/keypad_option_extended</item>
+        <item>@string/keypad_option_swapped</item>
+    </string-array>
+
+    <string-array name="keypad_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings_preference.xml
+++ b/app/src/main/res/values/strings_preference.xml
@@ -11,7 +11,11 @@
     <string name="previewConversion_summary">Show the current conversion for each rate in the currency picker.</string>
     <string name="extendedKeypad_key" translatable="false">KEY_EXTENDED_KEYPAD</string>
     <string name="extendedKeypad_title">Extended Keypad</string>
-    <string name="extendedKeypad_summary">Add two additional buttons: <b>00</b>&nbsp;and&nbsp;<b>000</b>.</string>
+    <string name="keypadType_key" translatable="false">KEY_KEYPAD_TYPE</string>
+    <string name="keypadType_title">Keypad Layout</string>
+    <string name="keypad_option_standard">Standard (0 on left)</string>
+    <string name="keypad_option_extended">Extended (00, 000)</string>
+    <string name="keypad_option_swapped">Swapped (0 in center)</string>
     <string name="category_appearance">Appearance</string>
     <string name="system_default">System default</string>
     <string name="theme_key" translatable="false">KEY_THEME</string>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -19,12 +19,14 @@
             android:title="@string/previewConversion_title"
             app:defaultValue="false" />
 
-        <SwitchPreferenceCompat
+        <ListPreference
+            android:defaultValue="0"
+            android:entries="@array/keypad_names"
+            android:entryValues="@array/keypad_values"
             android:icon="@drawable/ic_keyboard_extended"
-            android:key="@string/extendedKeypad_key"
-            android:summary="@string/extendedKeypad_summary"
-            android:title="@string/extendedKeypad_title"
-            app:defaultValue="false" />
+            android:key="@string/keypadType_key"
+            android:title="@string/keypadType_title"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
This is the standard layout for number keypads, here's a screenshot of how the Google Keyboard looks:
<img width="512" height="532" alt="image" src="https://github.com/user-attachments/assets/eab2863e-50d0-4c49-b254-8683dcad6e2d" />
And this is the new keyboard:
<img width="512" height="470" alt="image" src="https://github.com/user-attachments/assets/4eff026c-b264-4a14-b372-47e6a4d7ca50" />


This PR adds that option, while keeping the default with the separator in the middle, and also migrating the config changes for existing users. The only thing missing is the new translations, for all other languages besides English.